### PR TITLE
Command overriding

### DIFF
--- a/BotBits.Commands/Command.cs
+++ b/BotBits.Commands/Command.cs
@@ -65,6 +65,7 @@ namespace BotBits.Commands
             this.Names = command.Names ?? new string[0];
             this.Usages = command.Usages ?? new string[0];
             this.MinArgs = command.MinArgs;
+            this.Override = command.Override;
         }
 
         public string[] Names { get; private set; }
@@ -72,6 +73,8 @@ namespace BotBits.Commands
         public string[] Usages { get; private set; }
 
         public int MinArgs { get; private set; }
+
+        public bool Override { get; private set; }
 
         public Action<IInvokeSource, ParsedRequest> Callback { get; private set; }
     }

--- a/BotBits.Commands/CommandAttribute.cs
+++ b/BotBits.Commands/CommandAttribute.cs
@@ -27,6 +27,8 @@ namespace BotBits.Commands
             set { this.Usages = new[] {value}; }
         }
 
+        public bool Override { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandAttribute" /> class.
         /// </summary>

--- a/BotBits.Commands/CommandManager.cs
+++ b/BotBits.Commands/CommandManager.cs
@@ -187,7 +187,14 @@ namespace BotBits.Commands
         {
             lock (this._lockObj)
             {
-                if (command.Names.Any(this.ContainsInternal))
+                if (command.Override)
+                {
+                    foreach (var name in command.Names)
+                    {
+                        this._commands.Remove(name);
+                    }
+                }
+                else if (command.Names.Any(this.ContainsInternal))
                 {
                     throw new ArgumentException("A command with the given name has already been registered.");
                 }


### PR DESCRIPTION
This change allows users to override commands that already used one of selected command labels.

For example command marked override with labels ["exit", "quit"] would result in removal of already existing handlers of "exit" and "quit".

My use case is to be able to change logic behind commands inside of BotBits.DefaultCommands library.